### PR TITLE
Fix extension calls

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal=1
-
 [metadata]
 description-file=README.md

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,12 @@ dependency_links = [x.strip().replace('git+', '') for x in all_reqs if x.startsw
 from Cython.Build import cythonize
 import numpy as np
 extensions = [
-    Extension("fast_intensity/stair_step", ["fast_intensity/stair_step.pyx"],
-        include_dirs = [np.get_include()]),
-    Extension("fast_intensity/fast_hist", ["fast_intensity/fast_hist.pyx"],
-        include_dirs = [np.get_include()])
+    Extension(name="fast_intensity.stair_step",
+              sources=["fast_intensity/stair_step.pyx"],
+              include_dirs=[np.get_include()]),
+    Extension(name="fast_intensity.fast_hist",
+              sources=["fast_intensity/fast_hist.pyx"],
+              include_dirs=[np.get_include()]),
 ]
 
 setup(


### PR DESCRIPTION
Cython 0.28 [slightly altered its behavior](https://github.com/cython/cython/commit/f17ece062fb45e63f2fa56d857e1b72e58131482) in a way that revealed a latent bug in our setup script; according to the [distutils docs](https://docs.python.org/2/distutils/apiref.html#distutils.core.Extension) the first argument to `Extension` here should be the python dotted path name to the module.  With this patch we are installable using latest Cython, Numpy, and Python.