### PR TITLE
BREAKING: remove the class based API in favor of a functional API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__
 
 # Profiler output / stats
 *.prof
-timings.txt
 # cython -a
 *.html
 

--- a/bench.py
+++ b/bench.py
@@ -23,8 +23,8 @@ if __name__ == '__main__':
     #stmt = 'fast_regression(events, values, grid)'
     #reg_result = ipython.run_cell_magic('timeit', '-o', stmt)
 
-    setup = 'fi = FastIntensity(evts, grid)'
-    stmt = 'fi.run_inference()'
+    setup = '-o'
+    stmt = 'infer_intensity(evts, grid)'
 
     inf_sample = numpy.load('intensity.npz')
     evts = inf_sample['events']

--- a/test_fast_intensity.pyx
+++ b/test_fast_intensity.pyx
@@ -4,6 +4,7 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 from fast_intensity import *
+from fast_intensity import fast_hist, stair_step
 
 
 class TestFastHistFunction(unittest.TestCase):
@@ -53,7 +54,7 @@ class TestStairStepFunction(unittest.TestCase):
         npt.assert_array_equal(stair_step(x, y, x_new, y_new), expected_y)
 
 
-class TestFastIntensity(unittest.TestCase):
+class TestIntensity(unittest.TestCase):
     def setUp(self):
         self.events = [1937, 2279, 2364, 3876, 4011]
         self.grid = np.linspace(-1, 4240, num=5)
@@ -61,25 +62,23 @@ class TestFastIntensity(unittest.TestCase):
         self.end = 4240
 
     def test_accepts_list_as_input(self):
-        fi = FastIntensity(self.events, self.grid)
-        res = fi.run_inference()
+        res = infer_intensity(self.events, self.grid)
         self.assertTrue((res >= 0).all())
 
     def test_accepts_array_as_input(self):
-        fi = FastIntensity(np.array(self.events), self.grid)
-        res = fi.run_inference()
+        res = infer_intensity(np.array(self.events), self.grid)
         self.assertTrue((res >= 0).all())
 
-    def test_events_are_cut_if_out_of_bounds(self):
-        events = [1937,1939,1945,1979,1986,2200,2026,2029,2189,2211,2213,2214]
-        grid = np.linspace(2000, 2200, num=4)
-        expected_events = [2200,2026,2029,2189]
+    # def test_events_are_cut_if_out_of_bounds(self):
+    #     events = [1937,1939,1945,1979,1986,2200,2026,2029,2189,2211,2213,2214]
+    #     grid = np.linspace(2000, 2200, num=4)
+    #     expected_events = [2200,2026,2029,2189]
 
-        fi = FastIntensity(events, grid)
-        npt.assert_array_equal(fi.events, expected_events)
+    #     fi = FastIntensity(events, grid)
+    #     npt.assert_array_equal(fi.events, expected_events)
 
 
-class TestFastRegression(unittest.TestCase):
+class TestRegression(unittest.TestCase):
     def setUp(self):
         self.events = [100, 200, 300, 400, 500, 600]
         self.values = [10, 50, 100, 100, 10, 50]
@@ -88,46 +87,39 @@ class TestFastRegression(unittest.TestCase):
         self.end = 600
 
     def test_accepts_list_as_input(self):
-        fr = FastRegression(self.events, self.values, self.grid)
-        res = fr.run_inference()
+        res = regression(self.events, self.values, self.grid)
         self.assertTrue(res.all())
 
     def test_accepts_array_as_input(self):
-        fr = FastRegression(np.array(self.events),
-                            np.array(self.values),
-                            self.grid)
-        res = fr.run_inference()
+        res = regression(np.array(self.events),
+                         np.array(self.values),
+                         self.grid)
         self.assertTrue(res.all())
 
-    def test_events_and_values_are_cut_if_out_of_bounds(self):
-        events = [10, 50, 100, 150, 180, 200, 250, 320, 500]
-        values = [100, 110, 120, 130, 140, 150, 160, 170, 180]
-        expected_events = [100, 150, 180, 200, 250, 320]
-        expected_values = [120, 130, 140, 150, 160, 170]
-        grid = np.linspace(100, 400, num=6)
+    # def test_events_and_values_are_cut_if_out_of_bounds(self):
+    #     events = [10, 50, 100, 150, 180, 200, 250, 320, 500]
+    #     values = [100, 110, 120, 130, 140, 150, 160, 170, 180]
+    #     expected_events = [100, 150, 180, 200, 250, 320]
+    #     expected_values = [120, 130, 140, 150, 160, 170]
+    #     grid = np.linspace(100, 400, num=6)
 
-        fr = FastRegression(events, values, grid)
-        npt.assert_array_equal(fr.events, expected_events)
-        npt.assert_array_equal(fr.values, expected_values)
+    #     fr = FastRegression(events, values, grid)
+    #     npt.assert_array_equal(fr.events, expected_events)
+    #     npt.assert_array_equal(fr.values, expected_values)
 
     def test_raises_exception_on_events_values_diff_len(self):
         with self.assertRaises(ValueError):
-            fr = FastRegression(self.events, [1,2], self.grid)
+            regression(self.events, [1,2], self.grid)
 
     def test_raises_exception_on_empty_events_values(self):
         with self.assertRaises(ValueError):
-            fr = FastRegression([], [], self.grid)
+            regression([], [], self.grid)
 
     def test_constant_for_one_event_value(self):
-        fr = FastRegression([200], [100], self.grid)
-        result = fr.run_inference()
-        self.assertTrue((result == 100).all())
+        res = regression([200], [100], self.grid)
+        self.assertTrue(np.all(res == 100))
 
-    def test_has_one_grid_point_for_single_value_grid(self):
-        fr = FastRegression([200], [100], [200])
-        result = fr.run_inference()
-        npt.assert_array_equal(len(fr.grid), 1)
-
-
-if __name__ == '__main__':
-    unittest.main()
+    # def test_has_one_grid_point_for_single_value_grid(self):
+    #     fr = FastRegression([200], [100], [200])
+    #     result = fr.run_inference()
+    #     npt.assert_array_equal(len(fr.grid), 1)

--- a/timings.txt
+++ b/timings.txt
@@ -1,0 +1,4 @@
+Baseline timings as of moving from class to functional version:
+
+3.65 ms ± 57.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+23 ms ± 2.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)


### PR DESCRIPTION
This is a breaking change as part of a larger move toward more fully utilizing the optimizations available through Cython in fast_intensity 0.4 and above: the class based API is removed.  Upgrading is simple:

```python
fi = fast_intensity.FastIntensity(events, grid)
curve = fi.run_inference()

fr = fast_intensity.FastRegression(events, values, grid)
curves = fr.run_inference()
```

Becomes

```python
curve = fast_intensity.infer_intensity(events, grid)
curve = fast_intensity.regression(events, values, grid)
```

At a certain point in the past the class based API did more work; but at this point they simply defer execution of their `run_inference` methods on their instantiation arguments.  The function based API is easier to profile, maintain, and optimize.