### PR TITLE
Cdef inner funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ Usage
 
 ```python
 %matplotlib inline
+%load_ext cython
 import matplotlib.pyplot as plt
 import numpy as np
 import datetime as dt
+# If working locally rather than from a wheel or other binary
 import pyximport
-
 pyximport.install(language_level=3)
-from fast_intensity import FastIntensity
+from fast_intensity import infer_intensity
 
 np.random.seed(42)
 
@@ -58,18 +59,16 @@ events = np.sort(days[:100])
 grid = np.linspace(1, 365, num=12)
 
 # Generate the intensity curve - the unit is events per time unit
-fi = FastIntensity(events, grid)
-intensity = fi.run_inference()
-print(intensity)
-#     array([0.38953   , 0.27764734, 0.33549508, 0.27285165, 0.22284481,
-#            0.16997545, 0.26651725, 0.23580527, 0.23351076, 0.25272662,
-#            0.33146159, 0.28486727])
+curve = infer_intensity(events, grid)
+print(curve)
+#     array([0.38953   , 0.27764734, 0.33549508, 0.27285165, 0.22284481, 0.16997545,
+#            0.26651725, 0.23580527, 0.23351076, 0.25272662, 0.33146159, 0.28486727])
 
 plt.style.use('ggplot')
 fig, ax = plt.subplots(figsize=(9,9))
 ax.scatter(events, np.zeros(len(events)), alpha='0.4', label='Events')
 ax.scatter(grid, np.zeros(len(grid)) + 0.025, label='Grid')
-ax.plot(grid, intensity, label='Intensity')
+ax.plot(grid, curve, label='Intensity')
 plt.legend()
 plt.show()
 ```

--- a/fast_intensity.pxd
+++ b/fast_intensity.pxd
@@ -1,0 +1,8 @@
+# Cython header files like this enable us to cimport cdef and cpdef functions
+# from our pyx code (which allows us to test c only funcs)
+
+# cython: language_level=3
+
+cdef double[:] density_hist(double[:] x, double[:] edges)
+cdef double[:] stair_step(double[:] x, double[:] y, double[:] xp, double[:] yp)
+cdef double[:] get_sequence_boundaries(int num_bins, int num_events, int min_count)

--- a/fast_intensity.pyx
+++ b/fast_intensity.pyx
@@ -206,11 +206,8 @@ def infer_intensity(events, grid, iterations=100, min_count=3):
     -------
     np.ndarray[np.double_t, ndim=1] : Inferred intensity curve
     """
-    before_start = np.where(events < grid[0])
-    events = np.delete(events, before_start)
-
-    after_end = np.where(events > grid[-1])
-    events = np.delete(events, after_end)
+    events = np.asarray(events, dtype=np.double)
+    events = events[(grid[0] <= events) & (events <= grid[-1])]
 
     meanvals = np.zeros(len(grid))
     vals = np.zeros(len(grid))
@@ -269,17 +266,12 @@ def regression(events, values, grid):
     if len(events) == 0:
         raise ValueError("Events and values are empty.")
 
-    events = np.array(events, dtype=np.double)
-    values = np.array(values, dtype=np.double)
+    events = np.asarray(events, dtype=np.double)
+    values = np.asarray(values, dtype=np.double)
 
-    # Cut out of bounds values
-    before_start = np.where(events < grid[0])
-    values = np.delete(values, before_start)
-    events = np.delete(events, before_start)
-
-    after_end = np.where(events > grid[-1])
-    values = np.delete(values, after_end)
-    events = np.delete(events, after_end)
+    mask = (grid[0] <= events) & (events <= grid[-1])
+    events = events[mask]
+    values = values[mask]
 
     if len(events) == 1:
         return np.ones(len(grid)) * values[0]

--- a/fast_intensity.pyx
+++ b/fast_intensity.pyx
@@ -174,7 +174,7 @@ cdef double[:] get_sequence_boundaries(int num_bins, int num_events, int min_cou
         inner[i] += j
         j += min_count
 
-    cdef double[:] bounds = np.zeros(num_bins + 1)
+    cdef double[:] bounds = np.empty(num_bins + 1)
     bounds[0] = 0.0
     bounds[num_bins] = num_events + 1
     bounds[1:num_bins] = inner
@@ -234,7 +234,7 @@ def infer_intensity(events,
     # np.interpolate args xp and fp are precomputed for efficiency
     cdef np.ndarray xp = np.arange(0, n_evts + 2)
     # This is about 4-5x faster than using np.concatenate with lists
-    cdef np.ndarray fp = np.zeros(n_evts + 2)
+    cdef np.ndarray fp = np.empty(n_evts + 2)
     fp[0] = grid[0]
     fp[-1] = grid[-1]
     fp[1:-1] = events

--- a/fast_intensity.pyxbld
+++ b/fast_intensity.pyxbld
@@ -5,10 +5,12 @@ from setuptools import setup, Extension
 # developing on OS X, brew install GCC and symlink it into your path ahead of
 # clang.
 def make_ext(modname, pyxfilename):
-    return Extension('fast_intensity',
-                     ['fast_intensity.pyx'],
-                     extra_compile_args=['-fopenmp'],
-                     extra_link_args=['-fopenmp'],
-                     include_dirs=[numpy.get_include()])
+    return Extension(
+        'fast_intensity',
+        ['fast_intensity.pyx'],
+        #extra_compile_args=['-fopenmp', '-O3', '-march=native'],
+        #extra_link_args=['-fopenmp'],
+        include_dirs=[numpy.get_include()],
+    )
 
 # vim: ft=python

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,9 @@
 """
 Fast intensity inference
 """
-from codecs import open
 from os.path import abspath, dirname, join
 
 from setuptools import setup, Extension
-
-# Build time requires numpy and Cython
-# Runtime just requires numpy and scipy
 import numpy
 from Cython.Build import cythonize
 
@@ -15,8 +11,13 @@ readme_path = join(abspath(dirname(__file__)), 'README.md')
 with open(readme_path, encoding='utf-8') as file:
     DESCRIPTION = file.read()
 
-extensions = [Extension('fast_intensity', ['fast_intensity.pyx'],
-              include_dirs=[numpy.get_include()])]
+extensions = [
+    Extension(
+        'fast_intensity',
+        ['fast_intensity.pyx'],
+        include_dirs=[numpy.get_include()],
+    )
+]
 
 # Run the build
 setup(
@@ -37,7 +38,6 @@ setup(
     maintainer_email='john.m.still@vumc.org',
     long_description=DESCRIPTION,
     long_description_content_type='text/markdown',
-
     # Install data
     zip_safe=False,
     include_package_data=True,

--- a/test_fast_intensity.pyx
+++ b/test_fast_intensity.pyx
@@ -4,20 +4,20 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 from fast_intensity import *
-from fast_intensity import fast_hist, stair_step
+from fast_intensity cimport density_hist, stair_step
 
 
 class TestFastHistFunction(unittest.TestCase):
     def test_returns_correct_density_values_for_uniform_data(self):
         x = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=np.float)
         edges = np.array([0, 5.5, 11], dtype=np.float)
-        result = fast_hist(x, edges)
+        result = density_hist(x, edges)
         npt.assert_array_equal(result[0], result[1])
 
     def test_returns_correct_density_values_for_one_val(self):
         x = np.array([5], dtype=np.float)
         edges = np.array([4, 6], dtype=np.float)
-        self.assertEqual(fast_hist(x, edges), np.array([0.5]))
+        self.assertEqual(density_hist(x, edges), np.array([0.5]))
 
 
 class TestStairStepFunction(unittest.TestCase):

--- a/test_fast_intensity.pyx
+++ b/test_fast_intensity.pyx
@@ -69,13 +69,15 @@ class TestIntensity(unittest.TestCase):
         res = infer_intensity(np.array(self.events), self.grid)
         self.assertTrue((res >= 0).all())
 
-    # def test_events_are_cut_if_out_of_bounds(self):
-    #     events = [1937,1939,1945,1979,1986,2200,2026,2029,2189,2211,2213,2214]
-    #     grid = np.linspace(2000, 2200, num=4)
-    #     expected_events = [2200,2026,2029,2189]
-
-    #     fi = FastIntensity(events, grid)
-    #     npt.assert_array_equal(fi.events, expected_events)
+    def test_iteration_param(self):
+        # Iterations may be custom
+        infer_intensity(self.events, self.grid, iterations=1)
+        # Iteration count must be positive
+        with self.assertRaises(ValueError):
+            infer_intensity(self.events, self.grid, iterations=-1)
+        # Iteration count should be int
+        with self.assertRaises(TypeError):
+            infer_intensity(self.events, self.grid, iterations=1.5)
 
 
 class TestRegression(unittest.TestCase):
@@ -96,17 +98,6 @@ class TestRegression(unittest.TestCase):
                          self.grid)
         self.assertTrue(res.all())
 
-    # def test_events_and_values_are_cut_if_out_of_bounds(self):
-    #     events = [10, 50, 100, 150, 180, 200, 250, 320, 500]
-    #     values = [100, 110, 120, 130, 140, 150, 160, 170, 180]
-    #     expected_events = [100, 150, 180, 200, 250, 320]
-    #     expected_values = [120, 130, 140, 150, 160, 170]
-    #     grid = np.linspace(100, 400, num=6)
-
-    #     fr = FastRegression(events, values, grid)
-    #     npt.assert_array_equal(fr.events, expected_events)
-    #     npt.assert_array_equal(fr.values, expected_values)
-
     def test_raises_exception_on_events_values_diff_len(self):
         with self.assertRaises(ValueError):
             regression(self.events, [1,2], self.grid)
@@ -118,8 +109,3 @@ class TestRegression(unittest.TestCase):
     def test_constant_for_one_event_value(self):
         res = regression([200], [100], self.grid)
         self.assertTrue(np.all(res == 100))
-
-    # def test_has_one_grid_point_for_single_value_grid(self):
-    #     fr = FastRegression([200], [100], [200])
-    #     result = fr.run_inference()
-    #     npt.assert_array_equal(len(fr.grid), 1)

--- a/timings.txt
+++ b/timings.txt
@@ -1,4 +1,7 @@
-Baseline timings as of moving from class to functional version:
-
+Baseline timings after moving from class to functional version:
 3.65 ms ± 57.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
 23 ms ± 2.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
+
+Timings after fully Cythonizing density_hist and stair_step
+3.67 ms ± 50.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+15.6 ms ± 134 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

--- a/timings.txt
+++ b/timings.txt
@@ -2,6 +2,10 @@ Baseline timings after moving from class to functional version:
 3.65 ms ± 57.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
 23 ms ± 2.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
 
-Timings after fully Cythonizing density_hist and stair_step
+After (more) fully Cythonizing density_hist and stair_step
 3.67 ms ± 50.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
 15.6 ms ± 134 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+
+After extracting update_mean to a C loop
+3.03 ms ± 45.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+14.5 ms ± 149 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

--- a/timings.txt
+++ b/timings.txt
@@ -9,3 +9,7 @@ After (more) fully Cythonizing density_hist and stair_step
 After extracting update_mean to a C loop
 3.03 ms ± 45.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
 14.5 ms ± 149 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+
+Most things are now C typed
+2.1 ms ± 49.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+13.1 ms ± 161 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)


### PR DESCRIPTION
Before this update:
3.65 ms ± 57.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
23 ms ± 2.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

After this update:
2.1 ms ± 49.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
13.1 ms ± 161 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

Timings produced on an OS X i9 6-core using `bench.py`.